### PR TITLE
Removed superfluous(?) assignments to 'tail'

### DIFF
--- a/reusify.js
+++ b/reusify.js
@@ -2,7 +2,6 @@
 
 function reusify (Constructor) {
   var head = new Constructor()
-  var tail = head
 
   function get () {
     var current = head
@@ -11,7 +10,6 @@ function reusify (Constructor) {
       head = current.next
     } else {
       head = new Constructor()
-      tail = head
     }
 
     current.next = null
@@ -20,8 +18,7 @@ function reusify (Constructor) {
   }
 
   function release (obj) {
-    tail.next = obj
-    tail = obj
+    head.next = obj
   }
 
   return {


### PR DESCRIPTION
I've spent a few time trying to understand how `reusify`works.
Am I missing something (what?) or we don't really need to keep `tail` around?

On my macbook

```
$ node -v
v8.0.0

$ node benchmarks/reuseNoCodeFunctionNoTail.js
Total time 72071
Total iterations 100000000
Iteration/s 1387520.6393695108

node benchmarks/reuseNoCodeFunction.js
Total time 71658
Total iterations 100000000
Iteration/s 1395517.5974769043
```

On Windows

```
node -v
v8.4.0

node benchmarks\reuseNoCodeFunctionNoTail.js
Total time 94073
Total iterations 100000000
Iteration/s 1063004.262647093

node benchmarks\createNoCodeFunction.js
Total time 95570
Total iterations 100000000
Iteration/s 1046353.4581981794
```
